### PR TITLE
Enforce bonus token to be different from main token

### DIFF
--- a/contracts/core/HodlERC20.sol
+++ b/contracts/core/HodlERC20.sol
@@ -102,6 +102,7 @@ contract HodlERC20 is ERC20PermitUpgradeable, IHodlERC20 {
     require(_penalty < BASE, "INVALID_PENALTY");
     require(_fee < BASE, "INVALID_FEE");
     require(block.timestamp + _lockWindow < _expiry, "INVALID_EXPIRY");
+    require(address(_token) != address(_bonusToken), "INVALID_BONUS_TOKEN");
 
     totalTime = _expiry - block.timestamp;
 
@@ -224,10 +225,7 @@ contract HodlERC20 is ERC20PermitUpgradeable, IHodlERC20 {
    * @param _token token to donate (can be either a base token or a bonus token that was set up during the initialization)
    */
   function donate(uint256 _amount, address _token) external {
-    require(
-      address(_token) == address(token) || address(_token) == address(bonusToken),
-      "TOKEN_NOT_ALLOWED"
-    );
+    require(address(_token) == address(token) || address(_token) == address(bonusToken), "TOKEN_NOT_ALLOWED");
 
     emit Donate(msg.sender, _amount, _token);
 
@@ -249,19 +247,13 @@ contract HodlERC20 is ERC20PermitUpgradeable, IHodlERC20 {
    * @param _share number of shares
    * @param _tokenTotalReward total token amount for which to calculate a reward (either base or bonus token reward)
    */
-  function _rewardFromShares(uint256 _share, uint256 _tokenTotalReward)
-    internal
-    view
-    returns (uint256)
-  {
+  function _rewardFromShares(uint256 _share, uint256 _tokenTotalReward) internal view returns (uint256) {
     uint256 cachedPrecisionFactor = PRECISION_FACTOR;
 
     if (_tokenTotalReward > 0) {
-      uint256 payout = _tokenTotalReward
-      .mul(cachedPrecisionFactor)
-      .mul(_share)
-      .div(totalShares)
-      .div(cachedPrecisionFactor);
+      uint256 payout = _tokenTotalReward.mul(cachedPrecisionFactor).mul(_share).div(totalShares).div(
+        cachedPrecisionFactor
+      );
       return payout;
     } else {
       return 0;
@@ -328,19 +320,12 @@ contract HodlERC20 is ERC20PermitUpgradeable, IHodlERC20 {
    * @param _account account requesting
    * @param _amount amount of token quitting
    */
-  function _calculateSharesForceRedeem(address _account, uint256 _amount)
-    internal
-    view
-    returns (uint256)
-  {
+  function _calculateSharesForceRedeem(address _account, uint256 _amount) internal view returns (uint256) {
     uint256 totalCapital = balanceOf(_account);
     uint256 accountShares = _shares[_account];
     uint256 cachedPrecisionFactor = PRECISION_FACTOR;
 
-    return
-      _amount.mul(accountShares).mul(cachedPrecisionFactor).div(totalCapital).div(
-        cachedPrecisionFactor
-      );
+    return _amount.mul(accountShares).mul(cachedPrecisionFactor).div(totalCapital).div(cachedPrecisionFactor);
   }
 
   /**
@@ -376,10 +361,7 @@ contract HodlERC20 is ERC20PermitUpgradeable, IHodlERC20 {
   function _calculateShares(uint256 _amount) internal view returns (uint256) {
     uint256 timeLeft = expiry - block.timestamp;
     uint256 cachedPrecisionFactor = PRECISION_FACTOR;
-    return
-      _amount.mul(timeLeft**n).mul(cachedPrecisionFactor).div(totalTime**n).div(
-        cachedPrecisionFactor
-      );
+    return _amount.mul(timeLeft**n).mul(cachedPrecisionFactor).div(totalTime**n).div(cachedPrecisionFactor);
   }
 
   /**

--- a/contracts/core/HodlFactory.sol
+++ b/contracts/core/HodlFactory.sol
@@ -24,10 +24,7 @@ contract HodlSpawner {
    * from the spawned contract to the logic contract during contract creation
    * @return spawnedContract the address of the newly-spawned contract
    */
-  function _spawn(address logicContract, bytes memory initializationCalldata)
-    internal
-    returns (address)
-  {
+  function _spawn(address logicContract, bytes memory initializationCalldata) internal returns (address) {
     // place the creation code and constructor args of the contract to spawn in memory
     bytes memory initCode = abi.encodePacked(
       type(Spawn).creationCode,
@@ -120,16 +117,7 @@ contract HodlFactory is HodlSpawner {
     address _feeRecipient,
     address _bonusToken
   ) external returns (address newHodl) {
-    bytes32 id = _getHodlId(
-      _token,
-      _penalty,
-      _lockWindow,
-      _expiry,
-      _fee,
-      _n,
-      _feeRecipient,
-      _bonusToken
-    );
+    bytes32 id = _getHodlId(_token, _penalty, _lockWindow, _expiry, _fee, _n, _feeRecipient, _bonusToken);
     require(_idToAddress[id] == address(0), "CREATED");
     string memory name;
     string memory symbol;
@@ -163,18 +151,7 @@ contract HodlFactory is HodlSpawner {
     _isValidHToken[newHodl] = true;
     _idToAddress[id] = newHodl;
 
-    emit HodlCreated(
-      newHodl,
-      _token,
-      _penalty,
-      _lockWindow,
-      _expiry,
-      _fee,
-      _n,
-      _feeRecipient,
-      msg.sender,
-      _bonusToken
-    );
+    emit HodlCreated(newHodl, _token, _penalty, _lockWindow, _expiry, _fee, _n, _feeRecipient, msg.sender, _bonusToken);
 
     return newHodl;
   }
@@ -200,16 +177,7 @@ contract HodlFactory is HodlSpawner {
     address _feeRecipient,
     address _bonusToken
   ) external view returns (address) {
-    bytes32 id = _getHodlId(
-      _token,
-      _penalty,
-      _lockWindow,
-      _expiry,
-      _fee,
-      _n,
-      _feeRecipient,
-      _bonusToken
-    );
+    bytes32 id = _getHodlId(_token, _penalty, _lockWindow, _expiry, _fee, _n, _feeRecipient, _bonusToken);
     return _idToAddress[id];
   }
 
@@ -286,19 +254,7 @@ contract HodlFactory is HodlSpawner {
     address _feeRecipient,
     address _bonusToken
   ) internal pure returns (bytes32) {
-    return
-      keccak256(
-        abi.encodePacked(
-          _token,
-          _penalty,
-          _lockWindow,
-          _expiry,
-          _fee,
-          _n,
-          _feeRecipient,
-          _bonusToken
-        )
-      );
+    return keccak256(abi.encodePacked(_token, _penalty, _lockWindow, _expiry, _fee, _n, _feeRecipient, _bonusToken));
   }
 
   function _concat(string memory a, string memory b) internal pure returns (string memory) {

--- a/test/HodlERC20.ts
+++ b/test/HodlERC20.ts
@@ -142,6 +142,24 @@ describe("HodlERC20 Tests", function () {
         ).to.be.revertedWith("INVALID_EXPIRY");
       });
 
+      it("Should revert if bonus token is the same as main token", async function () {
+        const wrongLockingWindow = 86400 * 31;
+        await expect(
+          hodl.init(
+            token.address,
+            penalty,
+            lockingWindow,
+            expiry,
+            fee,
+            n,
+            feeRecipient.address,
+            name,
+            symbol,
+            token.address
+          )
+        ).to.be.revertedWith("INVALID_BONUS_TOKEN");
+      });
+
       it("Should init the contract", async function () {
         await hodl.init(
           token.address,

--- a/test/HodlERC20.ts
+++ b/test/HodlERC20.ts
@@ -143,7 +143,6 @@ describe("HodlERC20 Tests", function () {
       });
 
       it("Should revert if bonus token is the same as main token", async function () {
-        const wrongLockingWindow = 86400 * 31;
         await expect(
           hodl.init(
             token.address,


### PR DESCRIPTION
Discovered that it was possible to set the base token to the same address as main token while creating test pools yesterday. Wasn't causing bugs but could create confusion.