### PR TITLE
misc: add coverage report on Coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
       - compile-and-test:
           requires:
             - checkout-and-install
+          context: COVERALLS_REPO_TOKEN
 
 jobs:
   checkout-and-install:
@@ -53,6 +54,14 @@ jobs:
           name: Check Contracts Size
           command: npx hardhat size-contracts
       - run:
-          name: Test and Coverage
+          name: Coverage Report
           command: npx hardhat coverage
-      
+      - coveralls/upload:
+          path_to_lcov: ./coverage/lcov.info
+      - store_artifacts:
+          path: /coverage
+      - store_artifacts:
+          path: /coverage.json
+      - store_artifacts:
+          path: test-results.xml
+  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - compile-and-test:
           requires:
             - checkout-and-install
-          context: COVERALLS_REPO_TOKEN
+          context: BUILD_KEYS
 
 jobs:
   checkout-and-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,4 @@ jobs:
           path: /coverage
       - store_artifacts:
           path: /coverage.json
-      - store_artifacts:
-          path: test-results.xml
   

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ['mocks/', 'packages/']
+  skipFiles: ['mocks/', 'packages/','interfaces/']
 };

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hodl
 
+[![Coverage Status](https://coveralls.io/repos/github/hodlmybeer/hodl/badge.svg?branch=master)](https://coveralls.io/github/hodlmybeer/hodl?branch=master)
+
 <p align="center">
 <img src="./imgs/beers.png" width="100" height="100">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hodl
 
 [![Coverage Status](https://coveralls.io/repos/github/hodlmybeer/hodl/badge.svg?branch=master)](https://coveralls.io/github/hodlmybeer/hodl?branch=master)
+![Code Style](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)
 
 <p align="center">
 <img src="./imgs/beers.png" width="100" height="100">


### PR DESCRIPTION
### Setup coverage report on Coveralls. 

Coverage fail threshold: 95% (average including branch coverage)

All data will be available at https://coveralls.io/github/hodlmybeer/hodl