### PR TITLE
Fix the audit findings

### DIFF
--- a/contracts/core/HodlERC20.sol
+++ b/contracts/core/HodlERC20.sol
@@ -101,7 +101,7 @@ contract HodlERC20 is ERC20PermitUpgradeable {
     require(address(_token) != address(_bonusToken), "INVALID_BONUS_TOKEN");
     require(_feeRecipient != address(0), "INVALID_RECIPIENT");
 
-    totalTime = _expiry - block.timestamp;
+    totalTime = _expiry.sub(block.timestamp);
 
     token = IERC20WithDetail(_token);
     bonusToken = IERC20WithDetail(_bonusToken);

--- a/contracts/core/HodlERC20.sol
+++ b/contracts/core/HodlERC20.sol
@@ -143,7 +143,7 @@ contract HodlERC20 is ERC20PermitUpgradeable {
   /**
    * @dev deposit token into the contract.
    * the deposit amount will be stored under the account.
-   * the share you get is proportional to (time - expiry) / (start - expiry)
+   * the share you get is proportional to (expiry - time) / (expiry - start)
    * @param _amount amount of token to transfer into the Hodl contract
    */
   function deposit(uint256 _amount, address _recipient) external {
@@ -164,8 +164,8 @@ contract HodlERC20 is ERC20PermitUpgradeable {
   }
 
   /**
-   * @dev exist from the pool before expiry. Reverts if the pool is expired.
-   * @param _amount amount of token to exist
+   * @dev exit from the pool before expiry. Reverts if the pool is expired.
+   * @param _amount amount of token to exit
    */
   function quit(uint256 _amount) external {
     require(block.timestamp < expiry, "EXPIRED");
@@ -243,7 +243,7 @@ contract HodlERC20 is ERC20PermitUpgradeable {
    */
   function sweep(address _token, uint256 _amount) external {
     require(_token != address(token) && _token != address(bonusToken), "INVALID_TOKEN_TO_SWEEP");
-    IERC20WithDetail(_token).transfer(feeRecipient, _amount);
+    IERC20WithDetail(_token).safeTransfer(feeRecipient, _amount);
   }
 
   /**********************
@@ -359,7 +359,7 @@ contract HodlERC20 is ERC20PermitUpgradeable {
    *                      (total duration)^ n
    */
   function _calculateShares(uint256 _amount) internal view returns (uint256) {
-    uint256 timeLeft = expiry - block.timestamp;
+    uint256 timeLeft = expiry.sub(block.timestamp);
     return _amount.mul(timeLeft**n).div(totalTime**n);
   }
 


### PR DESCRIPTION
# Fixes
* PEV001: Use `safeTransfer` instead of transfer
* PEV002: Use `.sub` instead of `-` for time calculation
* PEV003: Update documentations to match the code.